### PR TITLE
2 intentos de 1 vuelta en clasificación

### DIFF
--- a/puntuacion.md
+++ b/puntuacion.md
@@ -19,7 +19,9 @@ La salida se realizará por detrás de la línea de meta y el cronómetro no emp
 
 Si el robot no consigue completar ninguno de los intentos, se tendrá en cuenta la distancia del trazado que haya sido capa de recorrer para determinar la clasificación. En el caso de que el robot no sea capaz de iniciar la salida por avería o problemas de puesta a punto se le permitirá repetir el intento. Si tras haberlo repetido no consigue iniciar la marcha, se anulará el intento.
 
-IMPORTANTE: En eventos con tiempo limitado, se podrá prescindir de la fase clasificatoria y pasar directamente a la fase eliminatoria. En ese caso, los robots con más puntos en el ranking de la ORS se considerarán los primeros de la clasificación.
+Se clasificarán los 4, 8 o 16 robots con mejor tiempo, a elección de la organización del evento, que lo comunicará antes de la realización de la competición. El número de robots clasificados definirá el número de rondas eliminatorias.
+
+IMPORTANTE: En eventos con tiempo limitado, se podrá prescindir de la fase clasificatoria y pasar directamente a la fase eliminatoria con todos los robots participantes. En ese caso, los robots con más puntos en el ranking de la ORS se considerarán los primeros de la clasificación.
 
 ## Fase eliminatoria
 

--- a/puntuacion.md
+++ b/puntuacion.md
@@ -8,13 +8,16 @@ La prueba se desarrollará en dos fase: clasificación y eliminatorias.
 
 ## Fase de clasificación
 
-Los robots competirán individualmente y deberán dar **3** vueltas consecutivas cronometradas al circuito. Solo se tendrá en cuenta el tiempo de la vuelta más rápida.
+Dos intentos de una vuelta, sin reprogramar el robot entre intentos (con el ordenador).
 
-Se permite que el participante elija el carril sobre el que circulará su robot. También se permite que el robot realice cambios de carril de forma autónoma durante la ejecución de la prueba.
+
+Los robots competirán individualmente en dos intentos de **1** vuelta cronometrada al circuito. Solo se tendrá en cuenta el tiempo de la vuelta más rápida para la clasificación y no se permite reprogramar el robot entre intentos.
+
+Se permite que el participante elija el carril sobre el que circulará su robot y que éste realice cambios de carril de forma autónoma durante la ejecución de la prueba.
 
 La salida se realizará por detrás de la línea de meta y el cronómetro no empezará a contar hasta que el robot la cruce.
 
-Si el robot no consigue completar las tres vueltas, solo se tendrá en cuenta el tiempo de las vueltas que haya completado. En el caso de que el robot no sea capaz de completar ni una sola vuelta (ya sea por salida de la pista, arranque nulo o cualquier otro incidente) se le permitirá realizar un segundo intento. Si tras el segundo intento el robot no consigue completar ninguna vuelta, clasificará en la última posición.
+Si el robot no consigue completar ninguno de los intentos, se tendrá en cuenta la distancia del trazado que haya sido capa de recorrer para determinar la clasificación. En el caso de que el robot no sea capaz de iniciar la salida por avería o problemas de puesta a punto se le permitirá repetir el intento. Si tras haberlo repetido no consigue iniciar la marcha, se anulará el intento.
 
 IMPORTANTE: En eventos con tiempo limitado, se podrá prescindir de la fase clasificatoria y pasar directamente a la fase eliminatoria. En ese caso, los robots con más puntos en el ranking de la ORS se considerarán los primeros de la clasificación.
 


### PR DESCRIPTION
Cambiado el modo de clasificación a 2 intentos de 1 vuelta, según lo hablado en la reunión del 5 de enero de 2019.
Este PR responde a la issue #8 